### PR TITLE
Add a primitive type for formatted strings

### DIFF
--- a/Sources/RichStringKit/Primitives/Formatted.swift
+++ b/Sources/RichStringKit/Primitives/Formatted.swift
@@ -1,0 +1,54 @@
+public struct Formatted: RichString {
+    public typealias Body = Never
+
+    let formatString: String
+    let args: [any RichString]
+
+    public init(
+        _ formatString: String,
+        _ args: (any RichString)...
+    ) {
+        self.formatString = formatString
+        self.args = args
+    }
+}
+
+extension Formatted {
+    public init(
+        _ formatString: String,
+        @RichStringBuilder arg0: () -> some RichString
+    ) {
+        self.formatString = formatString
+        self.args = [arg0()]
+    }
+
+    public init(
+        _ formatString: String,
+        @RichStringBuilder arg0: () -> some RichString,
+        @RichStringBuilder arg1: () -> some RichString
+    ) {
+        self.formatString = formatString
+        self.args = [arg0(), arg1()]
+    }
+
+    public init(
+        _ formatString: String,
+        @RichStringBuilder arg0: () -> some RichString,
+        @RichStringBuilder arg1: () -> some RichString,
+        @RichStringBuilder arg2: () -> some RichString
+    ) {
+        self.formatString = formatString
+        self.args = [arg0(), arg1(), arg2()]
+    }
+
+    public init(
+        _ formatString: String,
+        @RichStringBuilder arg0: () -> some RichString,
+        @RichStringBuilder arg1: () -> some RichString,
+        @RichStringBuilder arg2: () -> some RichString,
+        @RichStringBuilder arg3: () -> some RichString
+    ) {
+        self.formatString = formatString
+        self.args = [arg0(), arg1(), arg2(), arg3()]
+    }
+}

--- a/Sources/RichStringKit/Utilities/Collection+.swift
+++ b/Sources/RichStringKit/Utilities/Collection+.swift
@@ -1,0 +1,46 @@
+internal extension Collection {
+    func split(
+        maxSplits: Int = .max,
+        omittingEmptySubsequences: Bool = true,
+        whereSeparator isSeparator: (Index) throws -> Bool
+    ) rethrows -> [SubSequence] {
+        precondition(maxSplits >= 0, "Must take zero or more splits")
+
+        var result: [SubSequence] = []
+        var subSequenceStart: Index = startIndex
+
+        func appendSubsequence(end: Index) -> Bool {
+            if subSequenceStart == end && omittingEmptySubsequences {
+                return false
+            }
+            result.append(self[subSequenceStart..<end])
+            return true
+        }
+
+        if maxSplits == 0 || isEmpty {
+            _ = appendSubsequence(end: endIndex)
+            return result
+        }
+
+        var subSequenceEnd = subSequenceStart
+        let cachedEndIndex = endIndex
+        while subSequenceEnd != cachedEndIndex {
+            if try isSeparator(subSequenceEnd) {
+                let didAppend = appendSubsequence(end: subSequenceEnd)
+                formIndex(after: &subSequenceEnd)
+                subSequenceStart = subSequenceEnd
+                if didAppend && result.count == maxSplits {
+                    break
+                }
+                continue
+            }
+            formIndex(after: &subSequenceEnd)
+        }
+
+        if subSequenceStart != cachedEndIndex || !omittingEmptySubsequences {
+            result.append(self[subSequenceStart..<cachedEndIndex])
+        }
+
+        return result
+    }
+}

--- a/Sources/RichStringKit/Utilities/InterleavedSequence.swift
+++ b/Sources/RichStringKit/Utilities/InterleavedSequence.swift
@@ -1,0 +1,51 @@
+struct InterleavedSequence<First: Sequence, Second: Sequence>: Sequence where First.Element == Second.Element {
+    let first: First
+    let second: Second
+
+    init(first: First, second: Second) {
+        self.first = first
+        self.second = second
+    }
+
+    func makeIterator() -> Iterator {
+        Iterator(first: first.makeIterator(), second: second.makeIterator())
+    }
+}
+
+extension InterleavedSequence {
+    struct Iterator: IteratorProtocol {
+        enum State { case first, second, exhausted }
+
+        var first: First.Iterator
+        var second: Second.Iterator
+        var state = State.first
+
+        mutating func next() -> First.Element? {
+            switch state {
+            case .first:
+                guard let next = first.next() else {
+                    state = .exhausted
+                    return second.next()
+                }
+
+                state = .second
+                return next
+            case .second:
+                guard let next = second.next() else {
+                    state = .exhausted
+                    return first.next()
+                }
+                state = .first
+                return next
+            case .exhausted:
+                return first.next() ?? second.next()
+            }
+        }
+    }
+}
+
+extension Sequence {
+    func interleaved<S: Sequence>(with other: S) -> InterleavedSequence<Self, S> {
+        InterleavedSequence(first: self, second: other)
+    }
+}

--- a/Tests/RichStringKitTests/RichStringOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringOutputTests.swift
@@ -172,4 +172,69 @@ final class RichStringOutputTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    func testFormattedContent() {
+        let fixture = Fixture {
+            Formatted("Hello, %@!") {
+                "Swift"
+                    .font(.systemFont(ofSize: 20, weight: .bold))
+                    .backgroundColor(.orange)
+                    .foregroundColor(.white)
+            }
+            .font(.systemFont(ofSize: 20))
+        }
+
+        let output = fixture._makeOutput()
+        let expected: RichStringOutput = .init(
+            .modified(
+                .sequence([
+                    .string("Hello, "),
+                    .modified(
+                        .modified(
+                            .modified(
+                                .string("Swift"),
+                                .font(.systemFont(ofSize: 20, weight: .bold))
+                            ),
+                            .backgroundColor(.orange)
+                        ),
+                        .foregroundColor(.white)
+                    ),
+                    .string("!")
+                ]),
+                .font(.systemFont(ofSize: 20))
+            )
+        )
+
+        XCTAssertEqual(output, expected)
+    }
+
+    func testReduceContent() {
+        let fixture = Fixture {
+            "Welcome"
+                .foregroundColor(.blue)
+
+            " to the "
+                .kern(8)
+
+            "Jungle"
+                .backgroundColor(.red)
+
+            "!!"
+        }
+
+        let output = fixture._makeOutput()
+
+        guard case .content(let content) = output.storage else {
+            return XCTFail()
+        }
+
+        let string = content.reduce(into: "") { result, nextContent in
+            guard case .string(let str) = nextContent else {
+                return
+            }
+
+            result += str
+        }
+
+        XCTAssertEqual(string, "Welcome to the Jungle!!")
+    }
 }


### PR DESCRIPTION
This PR provides the basis for allowing formatted text in Rich Strings. 

### Usage

Apply specific styling to your format string arguments:

```Swift
let attr = NSAttributedString {
  Formatted("Hello, %@!) {
    "Swift"
      .font(.boldSystemFont(ofSize: 20)
      .foregroundColor(.white)
      .backgroundColor(.orange)
  }
  .font(.systemFont(ofSize: 20)
}
```
Result: 

<img width="280" alt="Screen Shot 2022-08-31 at 4 10 10 PM" src="https://user-images.githubusercontent.com/9791664/187772774-a4ab8cd3-f998-48c2-8d78-ecd65f61639a.png">

> Note: It is only recommended to use this type if you need to apply styling to the arguments separately from the whole formatted string. If you're entire formatted string uses the same styling, it is recommended to use `String(format:arguments:)` directly and apply style modifiers to that.

#### Known Issues

- This feature does not currently support consecutive format specifiers with no other text separating them (e.g. "%@%@"). Using consecutive specifiers may produce unexpected results.