### PR TITLE
Add Attachment as a RichString primitive to support Images 🖼️ 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "RichStringKit",
-    platforms: [.macOS(.v12), .iOS(.v15), .watchOS(.v7), .tvOS(.v15)],
+    platforms: [.macOS(.v12), .macCatalyst(.v15), .iOS(.v15), .watchOS(.v7), .tvOS(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/RichStringKit/Output/RichString+Output.swift
+++ b/Sources/RichStringKit/Output/RichString+Output.swift
@@ -22,6 +22,14 @@ extension String {
     public func _makeOutput() -> RichStringOutput { .init(.string(self)) }
 }
 
+// MARK: Attachment
+
+extension Attachment {
+    public func _makeOutput() -> RichStringOutput {
+        .init(.modified(.attachment, .attachment(image)))
+    }
+}
+
 // MARK: Concatenate
 
 extension Concatenate {

--- a/Sources/RichStringKit/Output/RichStringOutput.swift
+++ b/Sources/RichStringKit/Output/RichStringOutput.swift
@@ -12,12 +12,14 @@ public struct RichStringOutput: Equatable {
         case strikethroughStyle(LineStyle)
         case underlineColor(Color)
         case underlineStyle(LineStyle)
+        case attachment(Image)
         indirect case combined(Modifier, Modifier)
     }
 
     enum Content: Equatable {
         case empty
         case string(String)
+        case attachment
         indirect case modified(Content, Modifier)
         indirect case sequence([Content])
     }

--- a/Sources/RichStringKit/Primitives/Attachment.swift
+++ b/Sources/RichStringKit/Primitives/Attachment.swift
@@ -1,0 +1,26 @@
+#if os(macOS)
+import AppKit
+typealias Image = NSImage
+#else
+import UIKit
+typealias Image = UIImage
+#endif
+
+public struct Attachment: RichString {
+    public typealias Body = Never
+    public var body: Never { bodyAccessDisallowed() }
+
+    #if os(macOS)
+    public let image: NSImage
+
+    public init(_ image: NSImage) {
+        self.image = image
+    }
+    #else
+    public let image: UIImage
+
+    public init(_ image: UIImage) {
+        self.image = image
+    }
+    #endif
+}

--- a/Sources/RichStringKit/Primitives/Group.swift
+++ b/Sources/RichStringKit/Primitives/Group.swift
@@ -1,11 +1,7 @@
 public struct Group<Content>: RichString where Content: RichString {
-    var content: Content
+    public let body: Content
 
     public init(@RichStringBuilder _ content: () -> Content) {
-        self.content = content()
-    }
-
-    public var body: some RichString {
-        content
+        self.body = content()
     }
 }

--- a/Sources/RichStringKit/Rendering/ModifierMap.swift
+++ b/Sources/RichStringKit/Rendering/ModifierMap.swift
@@ -17,8 +17,15 @@ extension ModifierMap {
         self = content.reduce(into: ModifierMap()) { modifierMap, content in
             let nextPart = content
                 .reduce(into: "") { currentString, subContent in
-                    guard case .string(let str) = subContent else { return }
-                    currentString += str
+                    switch subContent {
+                    case .string(let string):
+                        currentString += string
+                    case .attachment:
+                        // Object Replacement Character
+                        currentString += "\u{FFFC}"
+                    default:
+                        return
+                    }
                 }
 
             let currentEndIndex = modifierMap.string.endIndex
@@ -32,7 +39,7 @@ extension ModifierMap {
                 modifierMap.rangedModifiers.append(
                     RangedModifier(range: range, modifier: modifier)
                 )
-            case .string:
+            case .string, .attachment:
                 modifierMap.string = updatedString
             default:
                 break

--- a/Sources/RichStringKit/Rendering/NSAttributedStringRenderer.swift
+++ b/Sources/RichStringKit/Rendering/NSAttributedStringRenderer.swift
@@ -48,6 +48,15 @@ enum NSAttributedStringRenderer: RichStringRenderer {
 private extension RichStringOutput.Modifier {
     func makeAttributes() -> NSAttributedStringRenderer.Attributes {
         switch self {
+        case .attachment(let image):
+            #if os(macOS)
+            let cell = NSTextAttachmentCell(imageCell: image)
+            let attachment = NSTextAttachment()
+            attachment.attachmentCell = cell
+            return [.attachment: attachment]
+            #else
+            return [.attachment: NSTextAttachment(image: image)]
+            #endif
         case .backgroundColor(let color):
             return [.backgroundColor: color]
         case .baselineOffset(let offset):

--- a/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
+++ b/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
@@ -48,8 +48,17 @@ final class NSAttributedStringRendererTests: XCTestCase {
             expected.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
         )
 
+        #if os(macOS)
+        let actualImage = try XCTUnwrap(
+            (actualAttachment.attachmentCell as? NSTextAttachmentCell)?.image
+        )
+        let expectedImage = try XCTUnwrap(
+            (expectedAttachment.attachmentCell as? NSTextAttachmentCell)?.image
+        )
+        #else
         let actualImage = try XCTUnwrap(actualAttachment.image)
         let expectedImage = try XCTUnwrap(expectedAttachment.image)
+        #endif
 
         // We have to test the images because two NSTextAttachment instances are never equal
         XCTAssertIdentical(actualImage, expectedImage)

--- a/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
+++ b/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
@@ -1,0 +1,191 @@
+//
+//  NSAttributedStringRendererTests.swift
+//  
+//
+//  Created by Robert Moyer on 9/13/22.
+//
+
+@testable import RichStringKit
+import XCTest
+
+final class NSAttributedStringRendererTests: XCTestCase {
+    private struct Fixture<Content: RichString>: RichString {
+        @RichStringBuilder var content: () -> Content
+        var body: some RichString { content() }
+    }
+
+    // MARK: - Primitives
+
+    func testEmpyString() {
+        let richString = EmptyString()
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString()
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testString() {
+        let richString = "Test"
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(string: "Test")
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testAttachment() throws {
+        let richString = Attachment(.testImage)
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(attachment: .attachment(using: .testImage))
+
+        let actualAttachment = try XCTUnwrap(
+            actual.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        )
+
+        let expectedAttachment = try XCTUnwrap(
+            expected.attribute(.attachment, at: 0, effectiveRange: nil) as? NSTextAttachment
+        )
+
+        let actualImage = try XCTUnwrap(actualAttachment.image)
+        let expectedImage = try XCTUnwrap(expectedAttachment.image)
+
+        // We have to test the images because two NSTextAttachment instances are never equal
+        XCTAssertIdentical(actualImage, expectedImage)
+    }
+
+    func testConcatenate() {
+        let richString = Concatenate("Hello ", EmptyString(), "World", "!!!", EmptyString())
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(string: "Hello World!!!")
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testModifiedContent() {
+        let richString = ModifiedContent(
+            content: "Test",
+            modifier: BaselineOffset(8)
+        )
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(
+            string: "Test",
+            attributes: [.baselineOffset: CGFloat(8)]
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testNestedContentModifiedContent() {
+        let richString = ModifiedContent(
+            content: ModifiedContent(
+                content: "Test",
+                modifier: BaselineOffset(8)
+            ),
+            modifier: Kern(8)
+        )
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(
+            string: "Test",
+            attributes: [
+                .baselineOffset: CGFloat(8),
+                .kern: CGFloat(8)
+            ]
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testNestedModifierModifiedContent() {
+        let richString = ModifiedContent(
+            content: "Test",
+            modifier: ModifiedContent(
+                content: BaselineOffset(8),
+                modifier: Kern(8)
+            )
+        )
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(
+            string: "Test",
+            attributes: [
+                .baselineOffset: CGFloat(8),
+                .kern: CGFloat(8)
+            ]
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    // MARK: - Compositions
+
+    func testGroupedModifiedContent() {
+        let richString = Fixture {
+            Group {
+                "Test".baselineOffset(8)
+            }.kern(8)
+        }
+
+        let actual = NSAttributedString(richString)
+        let expected = NSAttributedString(
+            string: "Test",
+            attributes: [
+                .baselineOffset: CGFloat(8),
+                .kern: CGFloat(8)
+            ]
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+
+    func testGroupedConcatenatedModifiedContent() throws {
+        let rawString = "Hello World!!!"
+        let richString = Fixture {
+            Group {
+                "Hello"
+                    .underlineStyle(.single)
+
+                " "
+
+                "World"
+                    .underlineStyle(.double)
+                    .strikethroughStyle(.single)
+
+                "!!!"
+                    .baselineOffset(8)
+            }.kern(8)
+        }
+
+        let actual = NSAttributedString(richString)
+
+        let helloRange = try XCTUnwrap(rawString.range(of: "Hello"))
+        let worldRange = try XCTUnwrap(rawString.range(of: "World"))
+        let punctuationRange = try XCTUnwrap(rawString.range(of: "!!!"))
+
+        let expected = NSMutableAttributedString(
+            string: "Hello World!!!",
+            attributes: [.kern: CGFloat(8)]
+        )
+
+        expected.addAttributes(
+            [.underlineStyle: NSUnderlineStyle.single.rawValue],
+            range: NSRange(helloRange, in: rawString)
+        )
+
+        expected.addAttributes(
+            [.underlineStyle: NSUnderlineStyle.double.rawValue, .strikethroughStyle: NSUnderlineStyle.single.rawValue],
+            range: NSRange(worldRange, in: rawString)
+        )
+
+        expected.addAttributes(
+            [.baselineOffset: CGFloat(8)],
+            range: NSRange(punctuationRange, in: rawString)
+        )
+
+        XCTAssertEqual(actual, expected)
+    }
+}

--- a/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
@@ -1,6 +1,12 @@
 import XCTest
 @testable import RichStringKit
 
+#if os(macOS)
+let image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)!
+#else
+let image = UIImage(systemName: "plus")!
+#endif
+
 final class RichStringBuilderOutputTests: XCTestCase {
 
     // MARK: - Content Tests
@@ -15,6 +21,13 @@ final class RichStringBuilderOutputTests: XCTestCase {
     func testStringOutput() {
         let output = "Test"._makeOutput()
         let expected = RichStringOutput(.string("Test"))
+
+        XCTAssertEqual(output, expected)
+    }
+
+    func testAttachmentOutput() {
+        let output = Attachment(image)._makeOutput()
+        let expected = RichStringOutput(.modified(.attachment, .attachment(image)))
 
         XCTAssertEqual(output, expected)
     }

--- a/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
@@ -1,12 +1,6 @@
 import XCTest
 @testable import RichStringKit
 
-#if os(macOS)
-let image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)!
-#else
-let image = UIImage(systemName: "plus")!
-#endif
-
 final class RichStringBuilderOutputTests: XCTestCase {
 
     // MARK: - Content Tests
@@ -26,8 +20,8 @@ final class RichStringBuilderOutputTests: XCTestCase {
     }
 
     func testAttachmentOutput() {
-        let output = Attachment(image)._makeOutput()
-        let expected = RichStringOutput(.modified(.attachment, .attachment(image)))
+        let output = Attachment(.testImage)._makeOutput()
+        let expected = RichStringOutput(.modified(.attachment, .attachment(.testImage)))
 
         XCTAssertEqual(output, expected)
     }

--- a/Tests/RichStringKitTests/RichStringBuilderTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderTests.swift
@@ -24,6 +24,15 @@ final class RichStringBuilderTests: XCTestCase {
         XCTAssertTrue(actualType == expectedType)
     }
 
+    func testAttachment() {
+        let content = Fixture(content: { Attachment(image) }).content()
+
+        let actualType = type(of: content)
+        let expectedType = Attachment.self
+
+        XCTAssertTrue(actualType == expectedType)
+    }
+
     func testMultipleStrings() {
         let content = Fixture {
             "Hello"

--- a/Tests/RichStringKitTests/RichStringBuilderTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderTests.swift
@@ -25,7 +25,7 @@ final class RichStringBuilderTests: XCTestCase {
     }
 
     func testAttachment() {
-        let content = Fixture(content: { Attachment(image) }).content()
+        let content = Fixture(content: { Attachment(.testImage) }).content()
 
         let actualType = type(of: content)
         let expectedType = Attachment.self

--- a/Tests/RichStringKitTests/Utilities/Image+Helper.swift
+++ b/Tests/RichStringKitTests/Utilities/Image+Helper.swift
@@ -1,0 +1,9 @@
+@testable import RichStringKit
+
+extension Image {
+    #if os(macOS)
+    static let testImage = Image(systemSymbolName: "plus", accessibilityDescription: nil)!
+    #else
+    static let testImage = Image(systemName: "plus")!
+    #endif
+}

--- a/Tests/RichStringKitTests/Utilities/NSTextAttachment+Helper.swift
+++ b/Tests/RichStringKitTests/Utilities/NSTextAttachment+Helper.swift
@@ -1,0 +1,20 @@
+@testable import RichStringKit
+
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
+extension NSTextAttachment {
+    static func attachment(using image: Image) -> NSTextAttachment {
+    #if os(macOS)
+        let cell = NSTextAttachmentCell(imageCell: image)
+        let attachment = NSTextAttachment()
+        attachment.attachmentCell = cell
+        return attachment
+    #else
+        return NSTextAttachment(image: image)
+    #endif
+    }
+}


### PR DESCRIPTION
This PR adds support for images via the `Attachment` primitive.

### Usage

Insert images into your strings:

```Swift
let attr = NSAttributedString {
    Group {
        Attachment(UIImage(systemName: "plus")!)
        " Add"
    }
    .font(.boldSystemFont(ofSize: 30))
    .foregroundColor(.systemBlue)
}
```

Result: 

<img width="140" alt="Screen Shot 2022-09-13 at 9 29 59 PM" src="https://user-images.githubusercontent.com/9791664/190038357-c3929c98-f9b4-4105-ba0e-ac5479f6ec5c.png">

