### PR TITLE
Enhance `RichStringBuilder` with support for control flow statements

### DIFF
--- a/Sources/RichStringKit/Output/RichString+Output.swift
+++ b/Sources/RichStringKit/Output/RichString+Output.swift
@@ -48,6 +48,17 @@ extension Concatenate {
     }
 }
 
+// MARK: Conditional Content
+
+extension ConditionalContent {
+    public func _makeOutput() -> RichStringOutput {
+        switch storage {
+        case .trueContent(let value):   return value._makeOutput()
+        case .falseContent(let value):  return value._makeOutput()
+        }
+    }
+}
+
 // MARK: Format
 
 extension Format {

--- a/Sources/RichStringKit/Primitives/ConditionalContent.swift
+++ b/Sources/RichStringKit/Primitives/ConditionalContent.swift
@@ -1,0 +1,11 @@
+public struct ConditionalContent<TrueContent, FalseContent>: RichString where TrueContent: RichString, FalseContent: RichString {
+    enum Storage {
+        case trueContent(TrueContent)
+        case falseContent(FalseContent)
+    }
+
+    let storage: Storage
+
+    public typealias Body = Never
+    public var body: Body { bodyAccessDisallowed() }
+}

--- a/Sources/RichStringKit/RichStringBuilder.swift
+++ b/Sources/RichStringKit/RichStringBuilder.swift
@@ -17,6 +17,12 @@ public enum RichStringBuilder {
         Concatenate(components)
     }
 
+    public static func buildArray(
+        _ components: [any RichString]
+    ) -> Concatenate {
+        Concatenate(components)
+    }
+
     public static func buildEither<TrueContent, FalseContent>(
         first: TrueContent
     ) -> ConditionalContent<TrueContent, FalseContent> where TrueContent: RichString, FalseContent: RichString {

--- a/Sources/RichStringKit/RichStringBuilder.swift
+++ b/Sources/RichStringKit/RichStringBuilder.swift
@@ -17,16 +17,16 @@ public enum RichStringBuilder {
         Concatenate(components)
     }
 
-    public static func buildEither<Content>(
-        first content: Content
-    ) -> Content where Content: RichString {
-        content
+    public static func buildEither<TrueContent, FalseContent>(
+        first: TrueContent
+    ) -> ConditionalContent<TrueContent, FalseContent> where TrueContent: RichString, FalseContent: RichString {
+        ConditionalContent(storage: .trueContent(first))
     }
 
-    public static func buildEither<Content>(
-        second content: Content
-    ) -> Content where Content: RichString {
-        content
+    public static func buildEither<TrueContent, FalseContent>(
+        second: FalseContent
+    ) -> ConditionalContent<TrueContent, FalseContent> where TrueContent: RichString, FalseContent: RichString {
+        ConditionalContent(storage: .falseContent(second))
     }
 
     public static func buildLimitedAvailability<Content>(

--- a/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
@@ -37,6 +37,25 @@ final class RichStringBuilderOutputTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    func testConditionalContentOutput() {
+        let trueContent = "Test".kern(8)
+        let falseContent = EmptyString()
+
+        let outputTrue = ConditionalContent<_, EmptyString>(
+            storage: .trueContent(trueContent)
+        )._makeOutput()
+
+        let outputFalse = ConditionalContent<ModifiedContent<String, Kern>, _>(
+            storage: .falseContent(falseContent)
+        )._makeOutput()
+
+        let expectedTrue = RichStringOutput(.modified(.string("Test"), .kern(8)))
+        let expectedFalse = RichStringOutput(RichStringOutput.Content.empty)
+
+        XCTAssertEqual(outputTrue, expectedTrue)
+        XCTAssertEqual(outputFalse, expectedFalse)
+    }
+
     func testFormatOutput() {
         let output0 = Format("%@", "Test")._makeOutput()
         let output1 = Format("%@%@", "Test", "Again")._makeOutput()

--- a/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
@@ -61,6 +61,7 @@ final class RichStringBuilderOutputTests: XCTestCase {
         let output1 = Format("%@%@", "Test", "Again")._makeOutput()
         let output2 = Format("Hello %@!", "Test")._makeOutput()
         let output3 = Format("%@ is a %@", "This", "Test")._makeOutput()
+        let output4 = Format("", "Test")._makeOutput()
 
         let expected0 = RichStringOutput(.sequence([.string("Test")]))
         let expected1 = RichStringOutput(.sequence([.string("Test"), .string("Again")]))
@@ -74,11 +75,13 @@ final class RichStringBuilderOutputTests: XCTestCase {
             .string(" is a "),
             .string("Test")
         ]))
+        let expected4 = RichStringOutput(.sequence([]))
 
         XCTAssertEqual(output0, expected0)
         XCTAssertEqual(output1, expected1)
         XCTAssertEqual(output2, expected2)
         XCTAssertEqual(output3, expected3)
+        XCTAssertEqual(output4, expected4)
     }
 
     func testModifiedContentOutput() {
@@ -112,6 +115,28 @@ final class RichStringBuilderOutputTests: XCTestCase {
                 .modified(.string("Hello"), .backgroundColor(.red)),
                 .modified(.string("World"), .kern(8)),
                 .modified(.string("!"), .baselineOffset(8)),
+            ])
+        )
+
+        XCTAssertEqual(output, expected)
+    }
+
+    func testLoopedContentOutput() {
+        struct Fixture: RichString {
+            let values = ["Hello", "Test", "World"]
+            var body: some RichString {
+                for value in values {
+                    value.kern(8)
+                }
+            }
+        }
+
+        let output = Fixture()._makeOutput()
+        let expected = RichStringOutput(
+            .sequence([
+                .modified(.string("Hello"), .kern(8)),
+                .modified(.string("Test"), .kern(8)),
+                .modified(.string("World"), .kern(8))
             ])
         )
 

--- a/Tests/RichStringKitTests/RichStringBuilderTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderTests.swift
@@ -45,6 +45,20 @@ final class RichStringBuilderTests: XCTestCase {
         XCTAssertTrue(actualType == expectedType)
     }
 
+    func testLooping() {
+        let values = ["Hello", "Test", "World"]
+        let content = Fixture {
+            for value in values {
+                value.kern(8)
+            }
+        }.content()
+
+        let actualType = type(of: content)
+        let expectedType = Concatenate.self
+
+        XCTAssertTrue(actualType == expectedType)
+    }
+
     func testSingleModifier() {
         let content = Fixture {
             "Test"

--- a/Tests/RichStringKitTests/RichStringBuilderTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderTests.swift
@@ -69,4 +69,20 @@ final class RichStringBuilderTests: XCTestCase {
 
         XCTAssertTrue(actualType == expectedType)
     }
+
+    func testBuildEither() {
+        let condition = true
+        let content = Fixture {
+            if condition {
+                "Test"
+            } else {
+                EmptyString()
+            }
+        }.content()
+
+        let actualType = type(of: content)
+        let expectedType = ConditionalContent<String, EmptyString>.self
+
+        XCTAssertTrue(actualType == expectedType)
+    }
 }


### PR DESCRIPTION
- Add a generic implementation of `buildEither(first:)` and `buildEither(second:)` to provide better support for if/else and switch statements. 
- Add `buildArray(_:)` to support loops in builder functions