### PR TITLE
Add convenience initializer to `Attachment` for more seamless SF Symbol support 🖼️ 

### DIFF
--- a/Sources/RichStringKit/Primitives/Attachment.swift
+++ b/Sources/RichStringKit/Primitives/Attachment.swift
@@ -17,10 +17,26 @@ public struct Attachment: RichString {
     public init(_ image: NSImage) {
         self.image = image
     }
+
+    public init?(systemName: String) {
+        guard let image = NSImage(
+            systemSymbolName: systemName,
+            accessibilityDescription: nil
+        ) else {
+            return nil
+        }
+
+        self.image = image
+    }
     #else
     public let image: UIImage
 
     public init(_ image: UIImage) {
+        self.image = image
+    }
+
+    public init?(systemName: String) {
+        guard let image = UIImage(systemName: systemName) else { return nil }
         self.image = image
     }
     #endif

--- a/Sources/RichStringKit/RichStringBuilder.swift
+++ b/Sources/RichStringKit/RichStringBuilder.swift
@@ -1,6 +1,5 @@
 @resultBuilder
 public enum RichStringBuilder {
-
     public static func buildExpression<Content>(
         _ expression: Content?
     ) -> ConditionalContent<Content, EmptyString> where Content: RichString {

--- a/Sources/RichStringKit/RichStringBuilder.swift
+++ b/Sources/RichStringKit/RichStringBuilder.swift
@@ -1,5 +1,26 @@
 @resultBuilder
 public enum RichStringBuilder {
+
+    public static func buildExpression<Content>(
+        _ expression: Content?
+    ) -> ConditionalContent<Content, EmptyString> where Content: RichString {
+        if let content = expression {
+            return ConditionalContent(storage: .trueContent(content))
+        } else {
+            return ConditionalContent(storage: .falseContent(EmptyString()))
+        }
+    }
+
+    public static func buildExpression(
+        _ expression: Never
+    ) -> Never { /* Cannot be executed */ }
+
+    public static func buildExpression<Content>(
+        _ expression: Content
+    ) -> Content where Content: RichString {
+        expression
+    }
+
     public static func buildBlock() -> some RichString {
         EmptyString()
     }


### PR DESCRIPTION
This PR adds a failable initializer to `Attachment`, which accepts a `systemName` for conveniently initializing images from SF Symbols.

As a side effect, this PR will allow Optional RichString values to be resolved in the result builder 🎉 