### PR TITLE
Fix failing build on watchOS due to unavailability of NSTextAttachment

### DIFF
--- a/Sources/RichStringKit/Output/RichString+Output.swift
+++ b/Sources/RichStringKit/Output/RichString+Output.swift
@@ -26,6 +26,7 @@ extension String {
 
 // MARK: Attachment
 
+@available(watchOS, unavailable)
 extension Attachment {
     public func _makeOutput() -> RichStringOutput {
         .init(.modified(.attachment, .attachment(image)))

--- a/Sources/RichStringKit/Output/RichStringOutput.swift
+++ b/Sources/RichStringKit/Output/RichStringOutput.swift
@@ -12,7 +12,10 @@ public struct RichStringOutput: Equatable {
         case strikethroughStyle(LineStyle)
         case underlineColor(Color)
         case underlineStyle(LineStyle)
+
+        @available(watchOS, unavailable)
         case attachment(Image)
+
         indirect case combined(Modifier, Modifier)
     }
 

--- a/Sources/RichStringKit/Primitives/Attachment.swift
+++ b/Sources/RichStringKit/Primitives/Attachment.swift
@@ -6,6 +6,7 @@ import UIKit
 typealias Image = UIImage
 #endif
 
+@available(watchOS, unavailable)
 public struct Attachment: RichString {
     public typealias Body = Never
     public var body: Never { bodyAccessDisallowed() }

--- a/Sources/RichStringKit/Rendering/NSAttributedStringRenderer.swift
+++ b/Sources/RichStringKit/Rendering/NSAttributedStringRenderer.swift
@@ -55,8 +55,10 @@ extension RichStringOutput.Modifier {
             let attachment = NSTextAttachment()
             attachment.attachmentCell = cell
             return [.attachment: attachment]
-            #else
+            #elseif !os(watchOS)
             return [.attachment: NSTextAttachment(image: image)]
+            #else
+            return [:]
             #endif
         case .backgroundColor(let color):
             return [.backgroundColor: color]

--- a/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
+++ b/Tests/RichStringKitTests/NSAttributedStringRendererTests.swift
@@ -34,6 +34,7 @@ final class NSAttributedStringRendererTests: XCTestCase {
         XCTAssertEqual(actual, expected)
     }
 
+    #if !os(watchOS)
     func testAttachment() throws {
         let richString = Attachment(.testImage)
 
@@ -63,6 +64,7 @@ final class NSAttributedStringRendererTests: XCTestCase {
         // We have to test the images because two NSTextAttachment instances are never equal
         XCTAssertIdentical(actualImage, expectedImage)
     }
+    #endif
 
     func testConcatenate() {
         let richString = Concatenate("Hello ", EmptyString(), "World", "!!!", EmptyString())

--- a/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderOutputTests.swift
@@ -18,12 +18,14 @@ final class RichStringBuilderOutputTests: XCTestCase {
         XCTAssertEqual(output, expected)
     }
 
+    #if !os(watchOS)
     func testAttachmentOutput() {
         let output = Attachment(.testImage)._makeOutput()
         let expected = RichStringOutput(.modified(.attachment, .attachment(.testImage)))
 
         XCTAssertEqual(output, expected)
     }
+    #endif
 
     func testConcatenateOutput() {
         let output = Concatenate(EmptyString(), "Test1", "Test2", EmptyString())

--- a/Tests/RichStringKitTests/RichStringBuilderTests.swift
+++ b/Tests/RichStringKitTests/RichStringBuilderTests.swift
@@ -26,6 +26,7 @@ final class RichStringBuilderTests: XCTestCase {
         XCTAssertTrue(actualType == expectedType)
     }
 
+    @available(watchOS, unavailable)
     func testAttachment() {
         let content = Fixture {
             Attachment(.testImage)

--- a/Tests/RichStringKitTests/Utilities/NSTextAttachment+Helper.swift
+++ b/Tests/RichStringKitTests/Utilities/NSTextAttachment+Helper.swift
@@ -6,6 +6,7 @@ import AppKit
 import UIKit
 #endif
 
+@available(watchOS, unavailable)
 extension NSTextAttachment {
     static func attachment(using image: Image) -> NSTextAttachment {
         #if os(macOS)


### PR DESCRIPTION
This PR addresses a build failure on watchOS that was caused by `NSTextAttachment` being unavailable on the platform. It also restricts availability of the `Attachment` type to exclude watchOS.